### PR TITLE
Disable minimize and stick buttons in a window titlebar

### DIFF
--- a/assets/fluxbox
+++ b/assets/fluxbox
@@ -11,3 +11,5 @@ session.screen0.strftimeFormat: %d %b, %a %02k:%M:%S
 session.screen0.toolbar.tools: prevworkspace, workspacename, nextworkspace, clock, prevwindow, nextwindow, iconbar, systemtray
 ! disable toolbar
 session.screen0.toolbar.visible:	false
+session.screen0.titlebar.left:
+session.screen0.titlebar.right: Maximize Close


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

Disables `minimize` and `stick` buttons in a window titlebar.

![image](https://user-images.githubusercontent.com/1636395/98693302-c8fcf200-2378-11eb-8b04-250e12042045.png)
